### PR TITLE
共通トピック削除APIを実装

### DIFF
--- a/src/main/kotlin/com/fun_topics_api/application/service/CommonTopicService.kt
+++ b/src/main/kotlin/com/fun_topics_api/application/service/CommonTopicService.kt
@@ -20,9 +20,15 @@ class CommonTopicService(
         //   本当は id 自動的に生成されるようにしたい
         commonTopicRepository.findAll().forEach {
             if (it.id == commonTopic.id) {
-                throw IllegalArgumentException("すでに存在するIDです")
+                throw IllegalArgumentException("すでに存在するIDです ${it.id}")
             }
         }
         commonTopicRepository.create(commonTopic)
+    }
+
+    @Transactional
+    fun deleteCommonTopic(id: Int) {
+        commonTopicRepository.find(id) ?: throw IllegalAccessException("存在しない共通トピックID: $id")
+        commonTopicRepository.delete(id)
     }
 }

--- a/src/main/kotlin/com/fun_topics_api/domain/CommonTopicRepository.kt
+++ b/src/main/kotlin/com/fun_topics_api/domain/CommonTopicRepository.kt
@@ -5,5 +5,9 @@ import com.fun_topics_api.domain.model.CommonTopic
 interface CommonTopicRepository {
     fun findAll(): List<CommonTopic>
 
+    fun find(id: Int): CommonTopic?
+
     fun create(commonTopic: CommonTopic)
+
+    fun delete(id: Int)
 }

--- a/src/main/kotlin/com/fun_topics_api/infrastructure/database/repository/CommonTopicRepositoryImpl.kt
+++ b/src/main/kotlin/com/fun_topics_api/infrastructure/database/repository/CommonTopicRepositoryImpl.kt
@@ -3,8 +3,10 @@ package com.fun_topics_api.infrastructure.database.repository
 import com.fun_topics_api.domain.CommonTopicRepository
 import com.fun_topics_api.domain.model.CommonTopic
 import com.fun_topics_api.infrastructure.database.mapper.CommonTopicsMapper
+import com.fun_topics_api.infrastructure.database.mapper.deleteByPrimaryKey
 import com.fun_topics_api.infrastructure.database.record.CommonTopicsRecord
 import com.fun_topics_api.infrastructure.database.mapper.insert
+import com.fun_topics_api.infrastructure.database.mapper.selectByPrimaryKey
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
@@ -17,9 +19,17 @@ class CommonTopicRepositoryImpl(
         return commonTopicsMapper.findAll().map { toModel(it) }
     }
 
+    override fun find(id: Int): CommonTopic? {
+        return commonTopicsMapper.selectByPrimaryKey(id)?.let { toModel(it) }
+    }
+
     override fun create(commonTopic: CommonTopic) {
         // recordをいれる
         commonTopicsMapper.insert(toRecord(commonTopic))
+    }
+
+    override fun delete(id: Int) {
+        commonTopicsMapper.deleteByPrimaryKey(id)
     }
 
     private fun toModel(record: CommonTopicsRecord): CommonTopic {

--- a/src/main/kotlin/com/fun_topics_api/presentation/controller/CommonTopicController.kt
+++ b/src/main/kotlin/com/fun_topics_api/presentation/controller/CommonTopicController.kt
@@ -32,4 +32,9 @@ class CommonTopicController(
             )
         )
     }
+
+    @DeleteMapping("/delete/{common_topic_id}")
+    fun delete(@PathVariable("common_topic_id") id: Int) {
+        commonTopicService.deleteCommonTopic(id)
+    }
 }


### PR DESCRIPTION
close #11 

## 処理の流れ
1. 共通トピック``id``から、削除対象トピックを取得
2. 取得できれば削除、取得できなければ例外をスロー

## 留意・保留事項
例外のメッセージやハンドリングの方法は改善の余地がありそう

